### PR TITLE
make maps silent to avoid :call noise in the commandline on motions

### DIFF
--- a/after/ftplugin/javascript/motions.vim
+++ b/after/ftplugin/javascript/motions.vim
@@ -3,35 +3,36 @@
 " Location: ftplugin/javascript/motions.vim
 " Author: Pascal Lalancette (okcompute@icloud.com)
 
-nnoremap <buffer> ]C  :<C-U>call javascript#motions#move_to_class('normal', 'foward')<CR>
-nnoremap <buffer> [C  :<C-U>call javascript#motions#move_to_class('normal', 'backward')<CR>
-nnoremap <buffer> ]M  :<C-U>call javascript#motions#move_to_function('normal', 'foward')<CR>
-nnoremap <buffer> [M  :<C-U>call javascript#motions#move_to_function('normal', 'backward')<CR>
-nnoremap <buffer> ]D  :<C-U>call javascript#motions#move_to_describe('normal', 'foward')<CR>
-nnoremap <buffer> [D  :<C-U>call javascript#motions#move_to_describe('normal', 'backward')<CR>
-nnoremap <buffer> ]I  :<C-U>call javascript#motions#move_to_it('normal', 'foward')<CR>
-nnoremap <buffer> [I  :<C-U>call javascript#motions#move_to_it('normal', 'backward')<CR>
-nnoremap <buffer> ]]  :<C-U>call javascript#motions#move_to_definition('normal','foward')<CR>
-nnoremap <buffer> [[  :<C-U>call javascript#motions#move_to_definition('normal','backward')<CR>
+nnoremap <silent> <buffer> ]C  :<C-U>call javascript#motions#move_to_class('normal', 'foward')<CR>
+nnoremap <silent> <buffer> [C  :<C-U>call javascript#motions#move_to_class('normal', 'backward')<CR>
+nnoremap <silent> <buffer> ]M  :<C-U>call javascript#motions#move_to_function('normal', 'foward')<CR>
+nnoremap <silent> <buffer> [M  :<C-U>call javascript#motions#move_to_function('normal', 'backward')<CR>
+nnoremap <silent> <buffer> ]D  :<C-U>call javascript#motions#move_to_describe('normal', 'foward')<CR>
+nnoremap <silent> <buffer> [D  :<C-U>call javascript#motions#move_to_describe('normal', 'backward')<CR>
+nnoremap <silent> <buffer> ]I  :<C-U>call javascript#motions#move_to_it('normal', 'foward')<CR>
+nnoremap <silent> <buffer> [I  :<C-U>call javascript#motions#move_to_it('normal', 'backward')<CR>
+nnoremap <silent> <buffer> ]]  :<C-U>call javascript#motions#move_to_definition('normal','foward')<CR>
+nnoremap <silent> <buffer> [[  :<C-U>call javascript#motions#move_to_definition('normal','backward')<CR>
 
-onoremap <buffer> ]C  :<C-U>call javascript#motions#move_to_class('normal', 'foward')<CR>
-onoremap <buffer> [C  :<C-U>call javascript#motions#move_to_class('normal', 'backward')<CR>
-onoremap <buffer> ]M  :<C-U>call javascript#motions#move_to_function('normal', 'foward')<CR>
-onoremap <buffer> [M  :<C-U>call javascript#motions#move_to_function('normal', 'backward')<CR>
-onoremap <buffer> ]D  :<C-U>call javascript#motions#move_to_describe('normal', 'foward')<CR>
-onoremap <buffer> [D  :<C-U>call javascript#motions#move_to_describe('normal', 'backward')<CR>
-onoremap <buffer> ]I  :<C-U>call javascript#motions#move_to_it('normal', 'foward')<CR>
-onoremap <buffer> [I  :<C-U>call javascript#motions#move_to_it('normal', 'backward')<CR>
-onoremap <buffer> ]]  :<C-U>call javascript#motions#move_to_definition('normal','foward')<CR>
-onoremap <buffer> [[  :<C-U>call javascript#motions#move_to_definition('normal','backward')<CR>
+onoremap <silent> <buffer> ]C  :<C-U>call javascript#motions#move_to_class('normal', 'foward')<CR>
+onoremap <silent> <buffer> [C  :<C-U>call javascript#motions#move_to_class('normal', 'backward')<CR>
+onoremap <silent> <buffer> ]M  :<C-U>call javascript#motions#move_to_function('normal', 'foward')<CR>
+onoremap <silent> <buffer> [M  :<C-U>call javascript#motions#move_to_function('normal', 'backward')<CR>
+onoremap <silent> <buffer> ]D  :<C-U>call javascript#motions#move_to_describe('normal', 'foward')<CR>
+onoremap <silent> <buffer> [D  :<C-U>call javascript#motions#move_to_describe('normal', 'backward')<CR>
+onoremap <silent> <buffer> ]I  :<C-U>call javascript#motions#move_to_it('normal', 'foward')<CR>
+onoremap <silent> <buffer> [I  :<C-U>call javascript#motions#move_to_it('normal', 'backward')<CR>
+onoremap <silent> <buffer> ]]  :<C-U>call javascript#motions#move_to_definition('normal','foward')<CR>
+onoremap <silent> <buffer> [[  :<C-U>call javascript#motions#move_to_definition('normal','backward')<CR>
 
-vnoremap <buffer> ]C  <Esc>:<C-U>call javascript#motions#move_to_class('visual', 'foward')<CR>
-vnoremap <buffer> [C  <Esc>:<C-U>call javascript#motions#move_to_class('visual', 'backward')<CR>
-vnoremap <buffer> ]M  <Esc>:<C-U>call javascript#motions#move_to_function('visual', 'foward')<CR>
-vnoremap <buffer> [M  <Esc>:<C-U>call javascript#motions#move_to_function('visual', 'backward')<CR>
-vnoremap <buffer> ]D  <Esc>:<C-U>call javascript#motions#move_to_describe('visual', 'foward')<CR>
-vnoremap <buffer> [D  <Esc>:<C-U>call javascript#motions#move_to_describe('visual', 'backward')<CR>
-vnoremap <buffer> ]I  <Esc>:<C-U>call javascript#motions#move_to_it('visual', 'foward')<CR>
-vnoremap <buffer> [I  <Esc>:<C-U>call javascript#motions#move_to_it('visual', 'backward')<CR>
-vnoremap <buffer> ]]  <Esc>:<C-U>call javascript#motions#move_to_definition('visual','foward')<CR>
-vnoremap <buffer> [[  <Esc>:<C-U>call javascript#motions#move_to_definition('visual','backward')<CR>
+vnoremap <silent> <buffer> ]C  <Esc>:<C-U>call javascript#motions#move_to_class('visual', 'foward')<CR>
+vnoremap <silent> <buffer> [C  <Esc>:<C-U>call javascript#motions#move_to_class('visual', 'backward')<CR>
+vnoremap <silent> <buffer> ]M  <Esc>:<C-U>call javascript#motions#move_to_function('visual', 'foward')<CR>
+vnoremap <silent> <buffer> [M  <Esc>:<C-U>call javascript#motions#move_to_function('visual', 'backward')<CR>
+vnoremap <silent> <buffer> ]D  <Esc>:<C-U>call javascript#motions#move_to_describe('visual', 'foward')<CR>
+vnoremap <silent> <buffer> [D  <Esc>:<C-U>call javascript#motions#move_to_describe('visual', 'backward')<CR>
+vnoremap <silent> <buffer> ]I  <Esc>:<C-U>call javascript#motions#move_to_it('visual', 'foward')<CR>
+vnoremap <silent> <buffer> [I  <Esc>:<C-U>call javascript#motions#move_to_it('visual', 'backward')<CR>
+vnoremap <silent> <buffer> ]]  <Esc>:<C-U>call javascript#motions#move_to_definition('visual','foward')<CR>
+vnoremap <silent> <buffer> [[  <Esc>:<C-U>call javascript#motions#move_to_definition('visual','backward')<CR>
+


### PR DESCRIPTION
This saves you from the `:call <javascript plugion motion call>` bit along the bottom